### PR TITLE
Bug 1210304 - fixed some David's comments

### DIFF
--- a/apps/verticalhome/index.html
+++ b/apps/verticalhome/index.html
@@ -100,7 +100,7 @@
       </div>
     </section>
 
-    <section id="more-apps-screen" role="region" hidden="">
+    <section id="more-apps-screen" role="region" class="hidden">
       <div class='more-apps-header'>More Apps</div>
       <gaia-grid-rs id="icons"></gaia-grid-rs>
 

--- a/apps/verticalhome/js/app.js
+++ b/apps/verticalhome/js/app.js
@@ -172,17 +172,17 @@
     showMoreApps: function() {
       this.inMoreApps = true;
       console.log("inMoreApps is : " + this.inMoreApps);
-      document.getElementById("main-screen").setAttribute("hidden","");
-      document.getElementById("more-apps-screen").removeAttribute("hidden");
+      document.getElementById("main-screen").classList.add('hidden');
+      document.getElementById("more-apps-screen").classList.remove('hidden');;
       MoreAppsNavigation.init();
       document.getElementsByTagName('gaia-grid-rs')[0].scrollTo(0,0);
     },
 
-    backToMainScreen: function() {
-      this.__proto__.inMoreApps = false;
+    hideMoreApps: function() {
+      this.inMoreApps = false;
       console.log("inMoreApps is : " + this.inMoreApps);
-      document.getElementById("main-screen").removeAttribute("hidden");
-      document.getElementById("more-apps-screen").setAttribute("hidden","");
+      document.getElementById("main-screen").classList.remove('hidden');
+      document.getElementById("more-apps-screen").classList.add('hidden');
     },
 
     /**
@@ -373,8 +373,7 @@
         // The system app changes the hash of the homescreen iframe when it
         // receives a home button press.
         case 'hashchange':
-
-          this.backToMainScreen();
+          this.hideMoreApps();
           this.pinNavigation.reset();
           this.clock.clockTime.parentNode.classList.remove('not-visible');
           this.clock.start();

--- a/apps/verticalhome/js/more_apps_navigation.js
+++ b/apps/verticalhome/js/more_apps_navigation.js
@@ -64,7 +64,7 @@
           break;
         case 'BrowserBack':
         case 'Backspace':
-          app.backToMainScreen();
+          app.hideMoreApps();
           break;
       }
     },

--- a/apps/verticalhome/style/css/app.css
+++ b/apps/verticalhome/style/css/app.css
@@ -13,6 +13,22 @@ body {
   overflow-x: hidden;
 }
 
+#main-screen.hidden,
+#more-apps-screen.hidden {
+  transition: all 0.5s ease 0s;
+  opacity: 0;
+  visibility: hidden;
+  height: 0;
+}
+
+#main-screen,
+#more-apps-screen {
+  transition: all 0.5s ease 0s;
+  opacity: 1;
+  visibility: visible;
+  height: 100%;
+}
+
 #more-apps-screen .more-apps-header {
   height: 50px;
   line-height: 50px;
@@ -98,11 +114,6 @@ gaia-grid-rs .icon.selected p {
 body.edit-group {
   overflow: hidden;
 }
-
-#main-screen{
-  height:100%;
-}
-
 
 #clock {
   width: 20rem;


### PR DESCRIPTION
1) Rather than using the hidden attribute here, it is probably better to set and remove a CSS class that will show the more apps screen on top of the main screen. That way you can specify CSS animations for the transition, which is what our UX designers have in mind, I think.
Done.
2) just use the hidden attribute with no value. No need for the =""
In accordance with previous comment changed to class.
3) If you ever have to use proto your code is almost certainly wrong. Accessing proto is also a big performance hit, since the code can't be optimized by the JS interpreter. You'll have to have a very good reason for proto and a long comment explaining the reason, or I will not land the patch.
Removed proto.
4) To be parallel with the function above, I'd suggest you call this hideMoreApps()
Renamed.
