### PR TITLE
Bug 1210304 - David's comment about number of columns in JSON

### DIFF
--- a/apps/verticalhome/build/default-homescreens.json
+++ b/apps/verticalhome/build/default-homescreens.json
@@ -22,8 +22,5 @@
       ["apps", "calendar"],
       ["apps", "costcontrol"]
     ]
-  ],
-  "preferences": {
-    "grid.cols": 2
-  }
+  ]
 }

--- a/apps/verticalhome/js/configurator.js
+++ b/apps/verticalhome/js/configurator.js
@@ -20,7 +20,9 @@
   var singleVariantApps = {};
   var simPresentOnFirstBoot = true;
 
-  var DEFAULT_PIN_APP_CONF_FILE = "js/pin_apps_default.json";
+  const DEFAULT_COLUMNS = 2;
+
+  var DEFAULT_PIN_APP_CONF_FILE = 'js/pin_apps_default.json';
   var pinAppsList = null;
 
   function loadSettingSIMPresent(currentMccMnc) {
@@ -139,15 +141,14 @@
    * Sets up the default columns.
    */
   function setupColumns() {
-    var defaultCols = conf && conf.preferences &&
-                          conf.preferences['grid.cols'] || undefined;
-
-    if (defaultCols) {
-      verticalPreferences.get('grid.cols').then(function(cols) {
-        // Set the number of cols by default in preference's datastore
-        !cols && verticalPreferences.put('grid.cols', defaultCols);
-      });
-    }
+    /**
+     * It is required for correct work of shared component 'gaia_grid_rs'.
+     * This function can be removed after refactoring of 'gaia_grid_rs'
+     */
+    verticalPreferences.get('grid.cols').then(function(cols) {
+      // Set the number of cols by default in preference's datastore
+      !cols && verticalPreferences.put('grid.cols', DEFAULT_COLUMNS);
+    });
   }
 
   function onErrorInitJSON(e) {
@@ -174,7 +175,7 @@
   }
 
   function onErrorPinApps(e) {
-    console.error("Failed Load Pin Apps:" + e);
+    console.error('Failed Load Pin Apps:' + e);
   }
 
   function load() {


### PR DESCRIPTION
David's comment:
"Given that the number of columns will not be configurable, I think that it doesn't need to be in this JSON file anymore. Maybe find the code that reads this file and just define a const for the number of columns."
Removed number of columns from default-homescreens.json. Define a const for the number of columns in configurator.js
