### PR TITLE
Bug 1220554 homescreen notifications

### DIFF
--- a/apps/system/manifest.webapp
+++ b/apps/system/manifest.webapp
@@ -142,6 +142,10 @@
     "places": {
       "access": "readwrite",
       "description": "Stores data about browsing history."
+    },
+    "notifications_count": {
+      "access": "readwrite",
+      "description": "Stores notifications count per app basis for the Homescreen tiles."
     }
   },
   "datastores-access": {

--- a/apps/verticalhome/js/pin_apps.js
+++ b/apps/verticalhome/js/pin_apps.js
@@ -12,7 +12,8 @@
     pinElem.className = 'pin-app-item';
     pinElem.setAttribute('data-index', this.index);
     pinElem.innerHTML = "<img class='pin-app-icon'><br></img>" +
-            "<span class='title'></span>";
+            "<span class='title'></span>" +
+            "<div class='unread_notif'></div>";
     var pinList = document.getElementById('pin-apps-list');
     var moreAppsLi = document.getElementById('moreApps');
     pinList.insertBefore(pinElem, moreAppsLi);
@@ -117,4 +118,70 @@
   };
 
   exports.PinAppManager = PinAppManager;
+
+  function ShowNotifBubble(appId,notifCount){
+
+      var els = document.getElementsByTagName('div');
+      var i = 0;
+
+      for (i = 0; i < els.length; i++) {
+        if (els[i].hasAttribute('data-manifesturl')) {
+          if (els[i].getAttribute('data-manifesturl') == appId) {
+
+            var unreadNotif = els[i].getElementsByClassName('unread_notif')[0];
+
+            /* start test part */
+            var notifCountBase = parseInt(unreadNotif.innerHTML || 0);
+            notifCountBase += notifCount;
+
+            if(notifCountBase > 999){
+              notifCountBase = 0;
+            }
+            /* end test part */
+
+            /* uncomment for real life */
+            // var notifCountBase;
+            // notifCountBase = parseInt(notifCount);
+            /* /uncomment for real life */
+
+            if(notifCountBase > 0 || notifCountBase){
+              unreadNotif.style.display = "block";
+              unreadNotif.innerHTML = notifCountBase;
+            }
+            else{
+              unreadNotif.style.display = "none";
+              unreadNotif.innerHTML = 0;
+            }
+          }
+
+        }
+      }
+  };
+
+window.addEventListener("keydown", function(e){
+
+  switch(e.keyCode){
+    case 49:
+      ShowNotifBubble('app://communications.gaiamobile.org/manifest.webapp',1);
+    break;
+
+    case 50:
+      ShowNotifBubble('app://sms.gaiamobile.org/manifest.webapp',1);
+    break;
+
+     case 51:
+      ShowNotifBubble('app://camera.gaiamobile.org/manifest.webapp',1);
+    break;
+
+     case 52:
+      ShowNotifBubble('app://settings.gaiamobile.org/manifest.webapp',1);
+    break;
+
+    default:
+      return;
+    break;
+  }
+
+});
+
 })(window);

--- a/apps/verticalhome/manifest.webapp
+++ b/apps/verticalhome/manifest.webapp
@@ -55,6 +55,10 @@
     "collections_store": {
       "readonly": false,
       "description": "Display collections"
+    },
+    "notifications_count": {
+      "readonly": true,
+      "description": "Display notifications counts."
     }
   },
   "datastores-owned": {

--- a/apps/verticalhome/style/css/pin_apps.css
+++ b/apps/verticalhome/style/css/pin_apps.css
@@ -53,6 +53,33 @@
   transition: all 0.5s;
 }
 
+#pin-apps-list .pin-app-item .unread_notif {
+  position: relative;
+  /* remove magic and put proper positioning & dynamic width change depending on characters count */
+  top: -7rem;
+  width: 1.3rem;
+  left: 0rem;
+  background-color: #e63d2f;
+  min-width: 0.7rem;
+  height: 1.3rem;
+  border-radius: 0.65rem;
+  text-align: center;
+  font-size: 1.1rem;
+  color: #FFF;
+  display: none;
+  font-weight: bold;
+}
+
+#pin-apps-list .selected .unread_notif {
+  min-width: 2rem;
+  height: 3rem;
+  border-radius: 1.5rem;
+  font-size: 2.4rem;
+  /* remove magic and put proper positioning & dynamic width change depending on characters count */
+  top: -16rem;
+  width: 3rem;
+}
+
 #pin-apps-list .pin-app-icon,
 #pin-apps-list input[type="button"] {
   width: 5rem;


### PR DESCRIPTION
@harman-red-square/harman-reviewers please review initial solution for homescreen notifications.

**NOTE!** _this PR shall not be merged into 'feature branch'! It submitted for review purposes only, and shall be rebased on top of feature branch after initial patch for Bug-1210304 will be fully reworked and landed._

Here is an initial implementation of 'notification bubbles' for homescreen.
List of required features/changes:
- [x] system app: added DataStore for accumulated notifications counts per application basis
- [x] homescreen: added tracking of changes in system's DataStore
- [x] counters reset for 'Clear all' button
- [x] bubbles on home recovered after restart
- [x] initial UI for notification bubbles ready
- [ ] update UI (mostly css styles) to comply with [UI spec](http://r1l8an.axshare.com/#p=1_2_notifications)
- [ ] remove extra debugging information (mostly could be found by searching `[el]` pattern)
- [ ] create unit tests for new functionality
- [ ] rework logic in `function ShowNotifBubble(appId,notifCount) {}` - it's really not good solution to iterate ower all `div` elements in the document.
