### PR TITLE
Bug 1202957 - added the first draft for Gecko numpad key hook R=?

### DIFF
--- a/apps/keyboard/build/build.js
+++ b/apps/keyboard/build/build.js
@@ -38,6 +38,7 @@ KeyboardAppBuilder.prototype.copyStaticFiles = function() {
                                'js/settings',
                                'js/shared',
                                'js/keyboard',
+                               'js/numpad',
                                'js/views');
 
   dirs.forEach(function(dirName) {

--- a/apps/keyboard/index.html
+++ b/apps/keyboard/index.html
@@ -4,7 +4,7 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1">
   <meta charset="utf-8">
   <title data-l10n-id="title">Keyboard</title>
-  <script defer type="text/javascript" src="js/keyboard/l10n_loader.js"></script>
+  <!--script defer type="text/javascript" src="js/keyboard/l10n_loader.js"></script>
   <script defer type="text/javascript" src="js/keyboard/user_press_manager.js"></script>
   <script defer type="text/javascript" src="js/keyboard/handwriting_pads_manager.js"></script>
   <script defer type="text/javascript" src="js/keyboard/alternatives_char_menu_manager.js"></script>
@@ -32,7 +32,9 @@
   <script defer type="text/javascript" src="js/keyboard/abortable_promise_queue.js"></script>
   <script defer type="text/javascript" src="js/keyboard/state_manager.js"></script>
   <script defer type="text/javascript" src="js/keyboard/keyboard_app.js"></script>
-  <script defer type="text/javascript" src="js/keyboard/bootstrap.js"></script>
+  <script defer type="text/javascript" src="js/keyboard/bootstrap.js"></script--!>
+  <script defer type="text/javascript" src="js/numpad/ninety.js"></script>
+  <script defer type="text/javascript" src="js/numpad/key_handler.js"></script>
 
   <!-- Shared code -->
   <!-- Let's lazily load l10n.js here because we don't want it to block

--- a/apps/keyboard/js/numpad/key_handler.js
+++ b/apps/keyboard/js/numpad/key_handler.js
@@ -1,0 +1,158 @@
+'use strict';
+
+(function(global) {
+
+    function _fetch(url, then){
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', url, true);
+        xhr.responseType = 'arraybuffer';
+
+        xhr.onload = function() {
+            if (xhr.status !== 404 &&
+                xhr.response &&
+                xhr.response.byteLength) {
+                then(xhr.response);
+            } else {
+                console.error("Numpad input: Failed to load " + url + " with status " + xhr.status + xhr.statusText);
+            }
+        };
+        
+        xhr.send();
+    }
+                            
+                            
+    var KeypadInput = function(){
+        navigator.mozInputMethod.addEventListener('numpadkeypress', this);
+    }
+
+    /* helpers */
+    function isWordChar(c){
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') 
+            || (c.charCodeAt(0) > 255); // now considering all unicode chars as words.
+    }
+    
+    function defWordBoundsFn(value, cursorPos){
+        var i = cursorPos;
+        while (i > 0 && isWordChar(value.charAt(i-1))) i--;
+        return { start: i, end: cursorPos };
+    }
+        
+    function NinetyLib() {
+        var ninety, self = this;
+
+        /* initialization */
+
+        _fetch('js/imes/latin/dictionaries/en_us.dict', function(dictionary) {
+            ninety = new Ninety(dictionary);
+        });
+
+        /* public interface implementation */
+
+        this.findWords = function(value){
+            if (ninety) {
+                return ninety.findWords("", value.split(''));
+            } else {
+                return [];
+            }
+        }
+
+        this.appendWord = function(value, key){
+            if (ninety) {
+                var keys = ninety.word2keys(value); // need to use this until 'prefix' feature is implemented for Ninety.findWords
+                return self.findWords(keys + key)[0];
+            }
+        }
+
+        this.getWordBounds = defWordBoundsFn;
+    }
+    
+    function MultitapLib(){
+        var self = this,
+        TAP_TIMEOUT = 1500,
+        keypad = {
+            '1': '.,?!-1',
+            '2': 'abcABC2',
+            '3': 'defDEF3',
+            '4': 'ghiGHI4',
+            '5': 'jklJKL5',
+            '6': 'mnoMNO6',
+            '7': 'pqrsPQRS7',
+            '8': 'tuvTUV8',
+            '9': 'wxyzWXYZ9',
+            '0': ' 0'
+        },
+        reverseKeypad = {}, 
+        inTimeout = false;  
+
+        for(var key in keypad){
+            for(var c of keypad[key]){
+                reverseKeypad[c] = key;
+            }
+        }
+        
+        function cancelTimer(){
+            inTimeout = false;
+        }
+        
+        /* public interface implementation */
+
+        this.findWords = function(value){
+            var c = value.charAt(value.length-1);
+            return keypad[c]? keypad[c].split(''): [];
+        }
+
+        this.appendWord = function(value, key){
+            var keys = keypad[key];
+            if (!keys) {
+                return false;
+            }
+            if (value.length > 0 && inTimeout) {
+                clearTimeout(inTimeout);
+                var lastChar = value.charAt(value.length - 1);
+                if (reverseKeypad[value.charAt(value.length - 1)] === key){
+                    // replace the previous character instead of adding a new one
+                    inTimeout = setTimeout(cancelTimer, TAP_TIMEOUT);
+                    var i = keys.indexOf(lastChar) + 1;
+                    if (i >= keys.length) {
+                        i = 0;
+                    }
+                    return value.substr(0, value.length - 1) + keys.charAt(i);
+                }
+            }
+            // add the first option for the sequence to the end and start the timer
+            inTimeout = setTimeout(cancelTimer, TAP_TIMEOUT);
+            return value + keys.charAt(0);
+        }
+
+        this.getWordBounds = defWordBoundsFn;    
+    }
+    
+    var matchers = [ new NinetyLib(), new MultitapLib() ];
+    
+    KeypadInput.prototype.handleEvent = function(evt) {
+        switch (evt.type) {
+            case 'numpadkeypress':
+                var key = evt.detail.key;
+                var bounds, word, result;
+                
+                var ctx = navigator.mozInputMethod.inputcontext;
+                var text = ctx.textBeforeCursor;
+                    
+                for (var matcher of matchers) {
+                    bounds = matcher.getWordBounds(text, text.length);
+                    word = text.substr(bounds.start, bounds.end - bounds.start);
+                    
+                    result = matcher.appendWord(word, key);
+                    if (result) {
+                        ctx.replaceSurroundingText(result,-word.length,word.length);
+                        //elem.selectionStart = elem.selectionEnd = bounds.start + result.length;
+                        return;
+                    }
+                }
+                break;
+        }
+    };
+
+global.KeypadInput = new KeypadInput();
+
+})(window);

--- a/apps/keyboard/js/numpad/ninety.js
+++ b/apps/keyboard/js/numpad/ninety.js
@@ -1,0 +1,249 @@
+var Ninety = (function() {
+  'use strict';
+
+  function Ninety(dictionary, keypadMap) {
+    this.initDictionary(dictionary);
+    this.keypadMap = keypadMap || Ninety.DEFAULT_KEYPAD_MAP;
+    
+    this.reverseKeypad = {};
+    for(var key in this.keypadMap){
+        for(var c of this.keypadMap[key]){
+            this.reverseKeypad[c] = key;
+        }
+    }
+  }
+
+  Ninety.DEFAULT_KEYPAD_MAP = {
+    '2': 'abcABC',
+    '3': 'defDEF',
+    '4': 'ghiGHI',
+    '5': 'jklJKL',
+    '6': 'mnoMNO',
+    '7': 'pqrsPQRS',
+    '8': 'tuvTUV',
+    '9': 'wxyzWXYZ'
+  };
+
+  // How much do we boost the frequency of complete words
+  Ninety.COMPLETE_WORD_BONUS = 2;
+
+  Ninety.prototype.initDictionary = function(dictionary) {
+    var file = new Uint8Array(dictionary);
+
+    function uint32(offset) {
+      return (file[offset] << 24) +
+        (file[offset + 1] << 16) +
+        (file[offset + 2] << 8) +
+        file[offset + 3];
+    }
+
+    function uint16(offset) {
+      return (file[offset] << 8) +
+        file[offset + 1];
+    }
+
+    if (uint32(0) !== 0x46784F53 ||   // "FxOS"
+        uint32(4) !== 0x44494354) {   // "DICT"
+      throw new Error('Invalid dictionary file');
+    }
+
+    if (uint32(8) !== 1) {
+      throw new Error('Unknown dictionary version');
+    }
+
+    // Read the maximum word length.
+    // We add 1 because word predictions can delete characters, so the
+    // user could type one extra character and we might still predict it.
+    this.maxWordLength = file[12] + 1;
+
+    // Skip the table of characters and frequencies.
+    var numEntries = uint16(13);
+
+    // The dictionary data begins right after the character table
+    this.tree = new Uint8Array(dictionary, 15 + numEntries * 6);
+  };
+
+  //
+  // This function unpacks binary data from the dictionary and returns
+  // the nodes of the dictionary tree in expanded form as JS objects.
+  // See gaia/dictionaries/xml2dict.py for the corresponding code that
+  // serializes the nodes of the tree into this binary format. Full
+  // documentation of the binary format is in that file.
+  //
+  Ninety.prototype.readNode = function(offset, node) {
+    if (offset === -1) {
+      throw Error('Assertion error: followed invalid pointer');
+    }
+
+    var firstbyte = this.tree[offset++];
+    var haschar = firstbyte & 0x80;
+    var bigchar = firstbyte & 0x40;
+    var hasnext = firstbyte & 0x20;
+    node.freq = (firstbyte & 0x1F) + 1;  // frequencies range from 1 to 32
+
+    if (haschar) {
+      node.ch = this.tree[offset++];
+      if (bigchar) {
+        node.ch = (node.ch << 8) + this.tree[offset++];
+      }
+    }
+    else {
+      node.ch = 0;
+    }
+
+    if (hasnext) {
+      node.next =
+        (this.tree[offset++] << 16) +
+        (this.tree[offset++] << 8) +
+        this.tree[offset++];
+    }
+    else {
+      node.next = -1;
+    }
+
+    if (haschar) {
+      node.center = offset;
+    } else {
+      node.center = -1;
+    }
+
+/*
+    log("readNode:" +
+        " haschar:" + haschar +
+        " bigchar:" + bigchar +
+        " hasnext:" + hasnext +
+        " freq:" + node.freq +
+        " char:" + node.ch +
+        " next:" + node.next +
+        " center:" + node.center);
+*/
+  };
+
+  /*
+   * Given a string prefix and an array of digits, return words or word
+   * prefixes that match
+   *
+   * TODO:
+   *
+   * DONE give words that are complete a frequency bump up
+   *
+   * find high frequency completions for high-frequency prefixes?
+   *   see what T9 does here
+   *
+   * Allow any punctuation characters that are not on any key
+   *
+   * add accents to the keypad map. Automate it so that case and
+   *  variants are automatically added? Also make a list of unmapped
+   *  characters that we'll add in for free
+   *
+   * measure perf
+   *
+   * add caching to improve performance especially when backspacing
+   *
+   * implement the prefix argument
+   *
+   * think about spelling correction. If the user wants to type "the"
+   * but types 834 instead of 843, should they get "the", or get
+   * "veg"? What does T9 do for common typos like this?
+   */
+  Ninety.prototype.findWords = function(prefix, digits) {
+    // XXX: we're going to assume that prefix is the empty string right now
+    // If not, we'll want to find the prefix in the tree and use that as the
+    // root of the search, I think.
+
+    // Start off with a list of one word, the empty string
+    var words = [{
+      pointer: 0,
+      output: ""
+    }];
+
+    for(var digit of digits) {
+      console.log("digit:", digit);
+      // These are the characters that map to that keypad digit
+      var keypadChars = this.keypadMap[digit];
+      if (!keypadChars) {
+        //throw new Error('Not a valid keypad digit: ' + digit);
+        return [];
+      }
+      // For each input digit we loop through all of the words we've
+      // got and see whether we can make any new, longer, words
+      var newwords = [];
+      var node = {}
+
+      for(var word of words) {
+        //console.log("word:", JSON.stringify(word));
+        // Read the node that represents this word, then loop through
+        // all of the letters that can follow it.
+        for(var pointer = word.pointer; pointer !== -1; pointer = node.next) {
+          this.readNode(pointer, node);
+
+          // What is the character here?
+          var char = String.fromCharCode(node.ch);
+
+          // If that character is one of the characters associated with
+          // this key of the keypad, then add it to the word
+          if (keypadChars.indexOf(char) >= 0) {
+            // console.log("Found a new word", word.output + char, node.freq);
+            newwords.push({
+              pointer: node.center,
+              frequency: node.freq,
+              output: word.output + char
+            });
+          }
+        }
+      }
+
+      // replace the old list of words with the new one
+      console.log("Ninety: had", words.length, "words, now have", newwords.length);
+      words = newwords;
+
+      // If at any point we have no candidate words, then we can
+      // return early.
+      if (words.length === 0) {
+        return [];
+      }
+    }
+
+    // Make another pass over the words and boost the frequency of
+    // words that are complete, so that they get shown in preference
+    // to prefixes
+    for(var word of words) {
+      var freq = this.isCompleteWord(word.pointer);
+      if (freq > 0) {
+        word.frequency = freq * Ninety.COMPLETE_WORD_BONUS;
+        console.log("Ninety:", word.output, "is a complete word with frequency", freq);
+      }
+    }
+
+    // After we've processed all the digits, sort the words by frequency
+    // and return an array of just the strings
+    return words.sort((a,b) => b.frequency - a.frequency).map(w => w.output);
+  };
+
+  // If the string at the specified pointer is a complete word, return the
+  // frequency of that word. If it is not a valid word, return false
+  Ninety.prototype.isCompleteWord = function(pointer) {
+    var node = {};
+
+    while(pointer !== -1) {
+      this.readNode(pointer, node);
+      if (node.ch === 0) {
+        return node.freq;
+      }
+      pointer = node.next;
+    }
+
+    return false;
+  };
+  
+  Ninety.prototype.word2keys = function(word){
+    var key, result = "";
+    for (var c of word) {
+        key = this.reverseKeypad[c];
+        if (key) result += key;
+    }
+    return result;
+  }
+
+  return Ninety;
+}());


### PR DESCRIPTION
This is just a dirty POC of how multitap and predictive numpad entry modes can be implemented.
The already known (but incomplete) list of TODOs contains:
    - discover a way to make numpad input as one of MozInput types (i.e. use existing interface
      instead of adding as a separate API)
    - add a setting to turn numpad functionality on-off and set it to 'on' by default for RedSquare
    - add a setting to turn on-screen keyboard (or other input methods) on-off and set it to 'off'
      by default for RedSquare
    - try using SetComposition interface instead of getting input text for better compatibility
      with other input methods
    - add a long-tap action(s) for '*' and/or 'hash' key
    - add last key event emulation (i.e. send the last char via existing "SendKey" API instead
      of replacing the whole word) for better app compatibility
